### PR TITLE
Manage in HTML 5 input attributes min, max and step

### DIFF
--- a/Leaflet.FormBuilder.js
+++ b/Leaflet.FormBuilder.js
@@ -243,6 +243,15 @@ L.FormBuilder.Input = L.FormBuilder.Element.extend({
         if (this.options.placeholder) {
             this.input.placeholder = this.options.placeholder;
         }
+        if (this.options.min != undefined) {
+            this.input.min = this.options.min;
+        }
+        if (this.options.max != undefined) {
+            this.input.max = this.options.max;
+        }
+        if (this.options.step) {
+            this.input.step = this.options.step;
+        }
         L.DomEvent.on(this.input, this.getSyncEvent(), this.sync, this);
         L.DomEvent.on(this.input, 'keydown', this.onKeyDown, this);
     },

--- a/Leaflet.FormBuilder.js
+++ b/Leaflet.FormBuilder.js
@@ -243,10 +243,10 @@ L.FormBuilder.Input = L.FormBuilder.Element.extend({
         if (this.options.placeholder) {
             this.input.placeholder = this.options.placeholder;
         }
-        if (this.options.min != undefined) {
+        if (this.options.min !== undefined) {
             this.input.min = this.options.min;
         }
-        if (this.options.max != undefined) {
+        if (this.options.max !== undefined) {
             this.input.max = this.options.max;
         }
         if (this.options.step) {


### PR DESCRIPTION
Attributes min, max and step to manage HTML 5 input were not there.
We added them in order to enhance opacity change in kosmtik/kosmtik-overlay@b79141fb3a6f6541e521764ff3c63e644c9299e2
They enable to use the mouse to change opacity by step (every n steps) instead of typing and also help limiting min, max values for input.

You can see how to configure an example at https://github.com/webgeodatavore/kosmtik-overlay/blob/html5attrs/front.js#L23

We didn't make a PR on kosmtik-overlay at the moment as it depends from this PR acceptation.
